### PR TITLE
feat(brew): manage homebrew trusted taps

### DIFF
--- a/dot_homebrew/private_trust.json
+++ b/dot_homebrew/private_trust.json
@@ -1,0 +1,10 @@
+{
+  "trustedformulae": [
+    "hashicorp/tap/terraform"
+  ],
+  "trustedtaps": [
+    "derailed/popeye",
+    "hashicorp/tap",
+    "norwoodj/tap"
+  ]
+}


### PR DESCRIPTION
Homebrew now requires third-party taps to be trusted (`brew trust`). Trusted entries live in `~/.homebrew/trust.json`, so this file is now managed by chezmoi — new machines get the taps (derailed/popeye, hashicorp/tap, norwoodj/tap) trusted out of the box, no more warnings during `brew bundle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)