### PR TITLE
chore(brew): remove berglas, swap insomnia back to bruno

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -52,7 +52,6 @@ personal_apps:
     - whatsapp
 relevanc:
   brews:
-    - berglas
     - colima
     - derailed/popeye/popeye
     - docker-buildx
@@ -73,9 +72,9 @@ relevanc:
     - terraform-docs
     - terragrunt
   casks:
+    - bruno
     - gcloud-cli
     - google-drive
-    - insomnia
 servier:
   brews:
     - glab


### PR DESCRIPTION
- `berglas`: never used, uninstalled locally as well
- `insomnia` → `bruno`: bruno is the API client actually in use (insomnia was not even installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)