### PR TITLE
feat(prompt): gruvbox-rainbow preset and ghostty rendering tuning

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,6 +1,11 @@
 # Ghostty — https://ghostty.org/docs/config
 font-family = MesloLGS Nerd Font
 font-size = 13
+# Match iTerm2's heavier glyph rendering and roomier line spacing
+font-thicken = true
+adjust-cell-height = 10%
+window-padding-x = 8
+window-padding-y = 6
 
 # Palette carried over from the old iTerm2 "Default" profile
 background = #1d262a

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -1,33 +1,209 @@
-# Starship prompt — https://starship.rs/config/
-add_newline = true
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+[](color_orange)\
+$os\
+$username\
+[](bg:color_yellow fg:color_orange)\
+$directory\
+[](fg:color_yellow bg:color_aqua)\
+$git_branch\
+$git_status\
+[](fg:color_aqua bg:color_blue)\
+$c\
+$cpp\
+$rust\
+$golang\
+$nodejs\
+$bun\
+$php\
+$java\
+$kotlin\
+$haskell\
+$python\
+[](fg:color_blue bg:color_bg3)\
+$gcloud\
+$kubernetes\
+$docker_context\
+$conda\
+$pixi\
+[](fg:color_bg3 bg:color_bg1)\
+$time\
+[ ](fg:color_bg1)\
+$line_break$character"""
+
+palette = 'gruvbox_dark'
+
+[palettes.gruvbox_dark]
+color_fg0 = '#fbf1c7'
+color_bg1 = '#3c3836'
+color_bg3 = '#665c54'
+color_blue = '#458588'
+color_aqua = '#689d6a'
+color_green = '#98971a'
+color_orange = '#d65d0e'
+color_purple = '#b16286'
+color_red = '#cc241d'
+color_yellow = '#d79921'
+
+[os]
+disabled = false
+style = "bg:color_orange fg:color_fg0"
+
+[os.symbols]
+Windows = "󰍲"
+Ubuntu = "󰕈"
+SUSE = ""
+Raspbian = "󰐿"
+Mint = "󰣭"
+Macos = "󰀵"
+Manjaro = ""
+Linux = "󰌽"
+Gentoo = "󰣨"
+Fedora = "󰣛"
+Alpine = ""
+Amazon = ""
+Android = ""
+AOSC = ""
+Arch = "󰣇"
+Artix = "󰣇"
+EndeavourOS = ""
+CentOS = ""
+Debian = "󰣚"
+Redhat = "󱄛"
+RedHatEnterprise = "󱄛"
+Pop = ""
+
+[username]
+show_always = true
+style_user = "bg:color_orange fg:color_fg0"
+style_root = "bg:color_orange fg:color_fg0"
+format = '[ $user ]($style)'
 
 [directory]
-truncation_length = 4
-truncate_to_repo = true
+style = "fg:color_fg0 bg:color_yellow"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
 
-[gcloud]
-# Active GCP project — shown whenever a gcloud config exists
-format = 'on [$symbol$project]($style) '
-symbol = '☁️  '
-style = 'bold blue'
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = "󰝚 "
+"Pictures" = " "
+"Developer" = "󰲋 "
 
-[kubernetes]
-# Context + namespace, only in kubernetes-flavoured directories
-disabled = false
-format = 'on [⎈ $context( \($namespace\))]($style) '
-style = 'bold cyan'
-detect_files = ['helmfile.yaml', 'Chart.yaml', 'kustomization.yaml', 'skaffold.yaml']
-detect_extensions = []
-detect_folders = ['helm', 'charts', 'manifests', 'k8s']
-
-[terraform]
-# Workspace only — version lookups slow the prompt down
-format = 'via [💠 $workspace]($style) '
+[git_branch]
+symbol = ""
+style = "bg:color_aqua"
+format = '[[ $symbol $branch ](fg:color_fg0 bg:color_aqua)]($style)'
 
 [git_status]
-ahead = '⇡${count}'
-behind = '⇣${count}'
-diverged = '⇕⇡${ahead_count}⇣${behind_count}'
+style = "bg:color_aqua"
+format = '[[($all_status$ahead_behind )](fg:color_fg0 bg:color_aqua)]($style)'
 
-[cmd_duration]
-min_time = 2000
+[nodejs]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[bun]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[c]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[cpp]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[php]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[java]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[kotlin]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[haskell]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[python]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[gcloud]
+# Active GCP project only — no region/account noise
+format = '[[ 󱇶 $project ](fg:#83a598 bg:color_bg3)]($style)'
+style = "bg:color_bg3"
+
+[kubernetes]
+# Context (+ namespace), only inside kubernetes-flavoured directories
+disabled = false
+format = '[[ 󱃾 $context(:$namespace) ](fg:#83a598 bg:color_bg3)]($style)'
+style = "bg:color_bg3"
+detect_files = ['helmfile.yaml', 'Chart.yaml', 'kustomization.yaml', 'skaffold.yaml']
+detect_folders = ['helm', 'charts', 'manifests', 'k8s']
+contexts = [
+  # gke_<project>_<region>_<cluster> → <cluster>
+  { context_pattern = 'gke_.*_(?P<cluster>[\w-]+)', context_alias = '$cluster' },
+]
+
+[aws]
+disabled = true
+
+[docker_context]
+symbol = ""
+style = "bg:color_bg3"
+format = '[[ $symbol( $context) ](fg:#83a598 bg:color_bg3)]($style)'
+
+[conda]
+style = "bg:color_bg3"
+format = '[[ $symbol( $environment) ](fg:#83a598 bg:color_bg3)]($style)'
+
+[pixi]
+style = "bg:color_bg3"
+format = '[[ $symbol( $version)( $environment) ](fg:color_fg0 bg:color_bg3)]($style)'
+
+[time]
+disabled = false
+time_format = "%R"
+style = "bg:color_bg1"
+format = '[[  $time ](fg:color_fg0 bg:color_bg1)]($style)'
+
+[line_break]
+disabled = false
+
+[character]
+disabled = false
+success_symbol = '[](bold fg:color_green)'
+error_symbol = '[](bold fg:color_red)'
+vimcmd_symbol = '[](bold fg:color_green)'
+vimcmd_replace_one_symbol = '[](bold fg:color_purple)'
+vimcmd_replace_symbol = '[](bold fg:color_purple)'
+vimcmd_visual_symbol = '[](bold fg:color_yellow)'


### PR DESCRIPTION
Feedback after the first ghostty/starship session:

- **Prompt noise**: the default starship config rendered the aws region (eu-west-3) and full GKE contexts. Now based on the `gruvbox-rainbow` preset whose explicit format only shows chosen segments: os, dir, git, languages, **gcloud project**, **kubernetes** (cluster name only, gke prefix stripped, k8s directories only), docker, time.
- **Rendering**: `font-thicken = true`, `adjust-cell-height = 10%` and window padding to match iTerm2's heavier, roomier look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)