### PR TITLE
chore: drop iterm2 remnants

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -1,2 +1,3 @@
 .local/alfred
 .p10k.zsh
+.iterm2_shell_integration.zsh

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -119,8 +119,6 @@ gch() {
 # Prompt — config in ~/.config/starship.toml
 eval "$(starship init zsh)"
 
-test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
-
 autoload -U +X bashcompinit && bashcompinit
 if command -v terragrunt &>/dev/null; then
   complete -o nospace -C "$(command -v terragrunt)" terragrunt


### PR DESCRIPTION
Ghostty adopted for good — iTerm2 uninstalled locally. Removes the shell integration sourcing from .zshrc and cleans ~/.iterm2_shell_integration.zsh on other machines via .chezmoiremove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)