### PR TITLE
chore(prompt): hide username, disable cmd duration

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -29,3 +29,7 @@ palette = 15=#ffffff
 
 macos-option-as-alt = true
 mouse-hide-while-typing = true
+
+# New tabs/windows always start in $HOME instead of inheriting the cwd
+working-directory = home
+window-inherit-working-directory = false

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -61,7 +61,7 @@ Redhat = "󱄛"
 RedHatEnterprise = "󱄛"
 
 [username]
-show_always = true
+show_always = false
 style_user = "bg:red fg:crust"
 style_root = "bg:red fg:crust"
 format = '[ $user]($style)'
@@ -188,10 +188,10 @@ vimcmd_replace_symbol = '[❮](bold fg:lavender)'
 vimcmd_visual_symbol = '[❮](bold fg:yellow)'
 
 [cmd_duration]
-show_milliseconds = true
+show_milliseconds = false
 format = " in $duration "
 style = "bg:lavender"
-disabled = false
+disabled = true
 show_notifications = true
 min_time_to_notify = 45000
 


### PR DESCRIPTION
Prompt tweaks: `username.show_always = false` (only shown when root/ssh) and `cmd_duration` disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)