### PR TITLE
chore(ghostty): catppuccin mocha theme, font size 14

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,28 +1,11 @@
 font-family = MesloLGS Nerd Font
-font-size = 13
+font-size = 14
 font-thicken = true
 adjust-cell-height = 10%
 window-padding-x = 8
 window-padding-y = 6
 
-background = #1d262a
-foreground = #e7ebed
-palette = 0=#435b67
-palette = 1=#fc3841
-palette = 2=#5cf19e
-palette = 3=#fed032
-palette = 4=#37b6ff
-palette = 5=#fc226e
-palette = 6=#59ffd1
-palette = 7=#ffffff
-palette = 8=#a1b0b8
-palette = 9=#fc746d
-palette = 10=#adf7be
-palette = 11=#fee16c
-palette = 12=#70cfff
-palette = 13=#fc669b
-palette = 14=#9affe6
-palette = 15=#ffffff
+theme = Catppuccin Mocha
 
 macos-option-as-alt = true
 mouse-hide-while-typing = true


### PR DESCRIPTION
Replaces the hand-carried iTerm2 palette with ghostty's built-in `Catppuccin Mocha` theme so the terminal matches the starship preset, and bumps the font to 14pt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)