### PR TITLE
feat(ghostty): quality-of-life settings

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -6,12 +6,24 @@ window-padding-x = 8
 window-padding-y = 6
 
 theme = Catppuccin Mocha
+background-opacity = 0.95
+background-blur = true
+minimum-contrast = 1.3
+cursor-style = bar
 
 macos-option-as-alt = true
+macos-titlebar-style = tabs
 mouse-hide-while-typing = true
 
 working-directory = home
 window-inherit-working-directory = false
 tab-inherit-working-directory = false
+window-save-state = always
 
 copy-on-select = clipboard
+
+shell-integration-features = ssh-env,ssh-terminfo
+
+auto-update = off
+
+keybind = global:cmd+grave_accent=toggle_quick_terminal


### PR DESCRIPTION
Settings reviewed against the installed version's reference docs:

- `keybind = global:cmd+grave_accent=toggle_quick_terminal` — quake-style dropdown terminal (needs Accessibility permission)
- `window-save-state = always` — restore windows/tabs/splits on relaunch
- `shell-integration-features = ssh-env,ssh-terminfo` — fixes TERM on remote ssh hosts
- `macos-titlebar-style = tabs`, `background-opacity = 0.95` + blur, `cursor-style = bar`, `minimum-contrast = 1.3`
- `auto-update = off` — the homebrew cask owns updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)