### PR TITLE
fix(git): push.default simple + branch.autoSetupMerge simple

### DIFF
--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -12,6 +12,7 @@
   ui = auto
 [branch]
   sort = -committerdate
+  autoSetupMerge = simple
 [color]
   ui = true
 [pull]
@@ -19,7 +20,7 @@
 [pager]
   branch = false
 [push]
-  default = upstream
+  default = simple
   followTags = true
   autoSetupRemote = true
   useForceIfIncludes = true


### PR DESCRIPTION
## Summary
- Configure `push.default = simple` so `git push` only pushes the current branch to its matching upstream
- Configure `branch.autoSetupMerge = simple` so new branches only track same-name upstream branches

These settings prevent accidental pushes to the wrong branch (e.g. pushing directly to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)